### PR TITLE
Added middleware to prevent render previews on the fly and return NOT_FOUND immediatly if there is no generated preview.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.2 -2021-06-30
+### Added
+- Added returning only rendered previews (configuring by setting 'enable_generated_previews_only': bool)
+
 ## 3.1.1 - 2021-01-27
 ### Changed
 - Use new batch preview method

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Preview Generator
 
+# CUSTOM CHANGES
+It is previewgenerator app with some additions: IT IS CHANGE preview behaviour.
+If there is no rendered preview, it is not trigger default preview system to generate it: just return 404 NOT_FOUND.
+If there is rendered preview, it is not change default behaviour and allows to return and render preview.
+Motivation: In case of upload so many pictures you could to view pictures which haven't generated previews. In this case nextcloud try to generate all of these and use all of system memory.
+To enable/disable feature, set enable_generated_previews_only : bool parameter in sesttings to true(default)/false.
+
 Nextcloud app that allows admins to pre-generate previews. The app listens to 
 edit events and stores this information. Once a cron job is triggered it will
 start preview generation. This means that you can better utilize your

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@ The first time you install this app, before using a cron job, you properly want 
 	</description>
 	<licence>AGPL</licence>
 	<author>Roeland Jago Douma</author>
-	<version>3.1.1</version>
+	<version>3.1.2</version>
 	<namespace>PreviewGenerator</namespace>
 	<category>multimedia</category>
 	<website>https://github.com/rullzer/previewgenerator</website>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -24,7 +24,9 @@ declare(strict_types=1);
  */
 namespace OCA\PreviewGenerator\AppInfo;
 
+use OC\AppFramework\Middleware\MiddlewareDispatcher;
 use OCA\PreviewGenerator\Listeners\PostWriteListener;
+use OCA\PreviewGenerator\Middleware\PreviewMiddleware;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -36,6 +38,10 @@ class Application extends App implements IBootstrap {
 
 	public function __construct() {
 		parent::__construct(self::APPNAME);
+
+		// Register middleware with deprecated method because modern method not working
+        $this->registerImagePreviewMiddleware();
+
 	}
 
 	public function register(IRegistrationContext $context): void {
@@ -44,4 +50,12 @@ class Application extends App implements IBootstrap {
 
 	public function boot(IBootContext $context): void {
 	}
+
+	private function registerImagePreviewMiddleware() : void {
+        $container = \OC::$server->query(\OC\Core\Application::class)->getContainer();
+        $container->registerService(PreviewMiddleware::class, function($c){
+            return new PreviewMiddleware($c->query('ServerContainer')->getDatabaseConnection());
+        });
+        $container->registerMiddleware(PreviewMiddleware::class);
+    }
 }

--- a/lib/Middleware/PreviewMiddleware.php
+++ b/lib/Middleware/PreviewMiddleware.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace OCA\PreviewGenerator\Middleware;
+
+use OC\Core\Controller\PreviewController;
+use OC\OCS\Exception;
+use OCP\IDBConnection;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Middleware;
+use OCP\Files\NotFoundException;
+use OCP\AppFramework\Http\DataResponse;
+
+class PreviewMiddleware extends Middleware {
+
+    /** @var IDBConnection */
+    private $connection;
+
+    public function __construct(IDBConnection $connection) {
+        $this->connection = $connection;
+    }
+
+    public function afterException($controller, $methodName, \Exception $exception) {
+        if ($exception instanceof NotFoundException) {
+            return new DataResponse([], Http::STATUS_NOT_FOUND);
+        }
+
+    }
+
+    public function isPreviewReady($fileId) : bool
+    {
+        $qb = $this->connection->getQueryBuilder();
+        $qb->select('id')
+            ->from('preview_generation')
+            ->where(
+                $qb->expr()->eq('file_id', $qb->createNamedParameter($fileId))
+            )->setMaxResults(1);
+        $cursor = $qb->execute();
+        $inTable = $cursor->fetch() !== false;
+        $cursor->closeCursor();
+
+        // If $fileId in queue to rendering, it is not ready for preview
+        return !$inTable;
+    }
+
+    public function beforeController($controller, $methodName)
+    {
+        if ($controller instanceof PreviewController) {
+            $config = \OC::$server->getConfig();
+
+            if (!$config->getSystemValue('enable_generated_previews_only', true)) {
+                // Just return in case of disabled plugin setting. So previewManager can generate preview on the fly.
+                return;
+            }
+
+            $root = \OC::$server->getRootFolder();
+            $userId = \OC::$server->getUserSession()->getUser()->getUID();
+            $request = \OC::$server->getRequest();
+            $userFolder = $root->getUserFolder($userId);
+            if (!$this->TryGetFileIdFromRequest($methodName, $userFolder, $request, $fileId))
+            {
+                throw new NotFoundException();
+            }
+
+            // Don't call deeper funtion because this $fileId in order to be generated
+            if (!$this->isPreviewReady($fileId)) {
+                throw new NotFoundException();
+            }
+        }
+    }
+
+    /**
+     * @param string $methodName
+     * @param \OCP\Files\Folder $userFolder
+     * @param \OCP\IRequest $request
+     * @param $fileId
+     */
+    public function TryGetFileIdFromRequest(string $methodName, \OCP\Files\Folder $userFolder, \OCP\IRequest $request, &$fileId): bool
+    {
+        try{
+            if ($methodName === 'getPreview') {
+                $fileId = $userFolder->get($request->getParam('file'))->getId();
+            } elseif ($methodName === 'getPreviewByFileId') {
+                $fileId = $request->getParam('fileId');
+            }
+            return true;
+        } catch (Exception $ex)
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Added middleware to prevent render previews on the fly and return NOT_FOUND immediatly if there is no generated preview.
Joint development with @anpavlov